### PR TITLE
Ship an explicit module descriptor in microprofile-rest-client-api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -64,4 +64,46 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <!--
+                        The module descriptor is compiled in a dedicated execution, patched onto the
+                        already compiled classes. This keeps the main compilation unchanged (class path)
+                        and avoids requiring the OSGi/bnd annotation jars referenced by package-info.java,
+                        which are compile-time only and ship no module descriptor.
+                    -->
+                    <execution>
+                        <id>compile-module-info</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/main/module-info</compileSourceRoot>
+                            </compileSourceRoots>
+                            <compilerArgs>
+                                <arg>--patch-module</arg>
+                                <arg>org.eclipse.microprofile.rest.client=${project.build.outputDirectory}</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <legacyMode>true</legacyMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,9 +99,35 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- The descriptor lives outside the javadoc source roots: keep the class path mode. -->
+                    <!--
+                        Keep javadoc in class path mode: a module-info.java at the root of a source path would switch
+                        it to module mode, so only the regular sources are documented.
+                    -->
                     <legacyMode>true</legacyMode>
+                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Register the descriptor source root only once compilation is over, so that the
+                        sources jar ships module-info.java while the default compilation keeps ignoring it.
+                    -->
+                    <execution>
+                        <id>add-module-info-source</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/main/module-info</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -79,7 +79,7 @@
                     -->
                     <execution>
                         <id>compile-module-info</id>
-                        <phase>compile</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -22,9 +22,14 @@
  * {@code @RestClient} is a {@code jakarta.inject.Qualifier} with an {@code AnnotationLiteral},
  * {@code @RegisterRestClient} is a CDI {@code @Stereotype} and providers are ordered with
  * {@code jakarta.annotation.Priority}, so those modules are required transitively.
+ *
+ * <p>
+ * {@code DefaultClientHeadersFactoryImpl} reads MicroProfile Config when it is available; the Config
+ * API is an optional ({@code provided}) dependency, hence {@code requires static}.
  */
 module org.eclipse.microprofile.rest.client {
     requires java.logging;
+    requires static org.eclipse.microprofile.config;
     requires transitive jakarta.annotation;
     requires transitive jakarta.cdi;
     requires transitive jakarta.inject;

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * MicroProfile Rest Client API.
+ *
+ * <p>
+ * The API exposes Jakarta REST types ({@code Response}, {@code MultivaluedMap}, {@code Configurable}),
+ * {@code @RestClient} is a {@code jakarta.inject.Qualifier} with an {@code AnnotationLiteral},
+ * {@code @RegisterRestClient} is a CDI {@code @Stereotype} and providers are ordered with
+ * {@code jakarta.annotation.Priority}, so those modules are required transitively.
+ */
+module org.eclipse.microprofile.rest.client {
+    requires java.logging;
+    requires transitive jakarta.annotation;
+    requires transitive jakarta.cdi;
+    requires transitive jakarta.inject;
+    requires transitive jakarta.ws.rs;
+
+    exports org.eclipse.microprofile.rest.client;
+    exports org.eclipse.microprofile.rest.client.annotation;
+    exports org.eclipse.microprofile.rest.client.ext;
+    exports org.eclipse.microprofile.rest.client.inject;
+    exports org.eclipse.microprofile.rest.client.spi;
+
+    uses org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
+    uses org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+}

--- a/api/src/main/module-info/module-info.java
+++ b/api/src/main/module-info/module-info.java
@@ -16,23 +16,13 @@
 
 /**
  * MicroProfile Rest Client API.
- *
- * <p>
- * The API exposes Jakarta REST types ({@code Response}, {@code MultivaluedMap}, {@code Configurable}),
- * {@code @RestClient} is a {@code jakarta.inject.Qualifier} with an {@code AnnotationLiteral},
- * {@code @RegisterRestClient} is a CDI {@code @Stereotype} and providers are ordered with
- * {@code jakarta.annotation.Priority}, so those modules are required transitively.
- *
- * <p>
- * {@code DefaultClientHeadersFactoryImpl} reads MicroProfile Config when it is available; the Config
- * API is an optional ({@code provided}) dependency, hence {@code requires static}.
  */
 module org.eclipse.microprofile.rest.client {
     requires java.logging;
     requires static org.eclipse.microprofile.config;
     requires transitive jakarta.annotation;
-    requires transitive jakarta.cdi;
-    requires transitive jakarta.inject;
+    requires static transitive jakarta.cdi;
+    requires static transitive jakarta.inject;
     requires transitive jakarta.ws.rs;
 
     exports org.eclipse.microprofile.rest.client;

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
@@ -71,6 +71,15 @@ public class ModuleDescriptorTest {
     }
 
     @Test
+    public void testOptionalConfigRequires() throws IOException {
+        Set<String> optional = descriptor().requires().stream()
+                .filter(r -> r.modifiers().contains(Modifier.STATIC))
+                .map(ModuleDescriptor.Requires::name)
+                .collect(Collectors.toSet());
+        assertEquals(optional, Set.of("org.eclipse.microprofile.config"));
+    }
+
+    @Test
     public void testServiceLoaderUses() throws IOException {
         assertEquals(descriptor().uses(), Set.of(
                 "org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener",

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
@@ -17,8 +17,8 @@
 package org.eclipse.microprofile.rest.client;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,7 +45,8 @@ public class ModuleDescriptorTest {
     public void testModuleName() throws IOException {
         ModuleDescriptor descriptor = descriptor();
         assertEquals(descriptor.name(), "org.eclipse.microprofile.rest.client");
-        assertTrue(!descriptor.isOpen() && !descriptor.isAutomatic());
+        assertFalse(descriptor.isOpen(), "the API module must not be an open module");
+        assertFalse(descriptor.isAutomatic(), "the API module must be an explicit module");
     }
 
     @Test

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.rest.client;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleDescriptor.Requires.Modifier;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.Test;
+
+/**
+ * Checks the explicit module descriptor shipped in the API jar.
+ */
+public class ModuleDescriptorTest {
+
+    private static ModuleDescriptor descriptor() throws IOException {
+        try (InputStream in = ModuleDescriptorTest.class.getResourceAsStream("/module-info.class")) {
+            assertNotNull(in, "module-info.class must be present at the root of the API classes");
+            return ModuleDescriptor.read(in);
+        }
+    }
+
+    @Test
+    public void testModuleName() throws IOException {
+        ModuleDescriptor descriptor = descriptor();
+        assertEquals(descriptor.name(), "org.eclipse.microprofile.rest.client");
+        assertTrue(!descriptor.isOpen() && !descriptor.isAutomatic());
+    }
+
+    @Test
+    public void testExportedPackages() throws IOException {
+        Set<String> exported = descriptor().exports().stream()
+                .map(ModuleDescriptor.Exports::source)
+                .collect(Collectors.toSet());
+        assertEquals(exported, Set.of(
+                "org.eclipse.microprofile.rest.client",
+                "org.eclipse.microprofile.rest.client.annotation",
+                "org.eclipse.microprofile.rest.client.ext",
+                "org.eclipse.microprofile.rest.client.inject",
+                "org.eclipse.microprofile.rest.client.spi"));
+    }
+
+    @Test
+    public void testTransitiveRequires() throws IOException {
+        Set<String> transitive = descriptor().requires().stream()
+                .filter(r -> r.modifiers().contains(Modifier.TRANSITIVE))
+                .map(ModuleDescriptor.Requires::name)
+                .collect(Collectors.toSet());
+        assertEquals(transitive, Set.of("jakarta.annotation", "jakarta.cdi", "jakarta.inject", "jakarta.ws.rs"));
+    }
+
+    @Test
+    public void testServiceLoaderUses() throws IOException {
+        assertEquals(descriptor().uses(), Set.of(
+                "org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener",
+                "org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver"));
+    }
+}

--- a/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/rest/client/ModuleDescriptorTest.java
@@ -71,12 +71,21 @@ public class ModuleDescriptorTest {
     }
 
     @Test
-    public void testOptionalConfigRequires() throws IOException {
+    public void testOptionalRequires() throws IOException {
         Set<String> optional = descriptor().requires().stream()
                 .filter(r -> r.modifiers().contains(Modifier.STATIC))
                 .map(ModuleDescriptor.Requires::name)
                 .collect(Collectors.toSet());
-        assertEquals(optional, Set.of("org.eclipse.microprofile.config"));
+        assertEquals(optional, Set.of("jakarta.cdi", "jakarta.inject", "org.eclipse.microprofile.config"));
+    }
+
+    @Test
+    public void testMandatoryRequires() throws IOException {
+        Set<String> mandatory = descriptor().requires().stream()
+                .filter(r -> !r.modifiers().contains(Modifier.STATIC))
+                .map(ModuleDescriptor.Requires::name)
+                .collect(Collectors.toSet());
+        assertEquals(mandatory, Set.of("java.base", "java.logging", "jakarta.annotation", "jakarta.ws.rs"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
     <url>http://microprofile.io</url>
 
     <properties>
+        <!--
+            3.1.1 is the first Config API release with an Automatic-Module-Name (org.eclipse.microprofile.config),
+            which the api module descriptor targets with `requires static`; 3.1 only had the jar-derived name.
+        -->
         <version.mp.config>3.1.1</version.mp.config>
         <inceptionYear>2017</inceptionYear>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <url>http://microprofile.io</url>
 
     <properties>
-        <version.mp.config>3.1</version.mp.config>
+        <version.mp.config>3.1.1</version.mp.config>
         <inceptionYear>2017</inceptionYear>
         <version.jakarta.ee>10.0.0</version.jakarta.ee>
         <version.microprofile.tck.bom>3.4</version.microprofile.tck.bom>


### PR DESCRIPTION
Fixes #408

Adds an explicit `module-info.java` to `microprofile-rest-client-api` so the MicroProfile Rest Client API can be consumed as a proper Java module instead of an automatic one (context: [mailing-list thread](https://groups.google.com/g/microprofile/c/h2e3FicNw5k), same change proposed for every affected MicroProfile API).

### The descriptor

```java
module org.eclipse.microprofile.rest.client {
    requires java.logging;
    requires static org.eclipse.microprofile.config;
    requires transitive jakarta.annotation;
    requires static transitive jakarta.cdi;
    requires static transitive jakarta.inject;
    requires transitive jakarta.ws.rs;

    exports org.eclipse.microprofile.rest.client;
    exports org.eclipse.microprofile.rest.client.annotation;
    exports org.eclipse.microprofile.rest.client.ext;
    exports org.eclipse.microprofile.rest.client.inject;
    exports org.eclipse.microprofile.rest.client.spi;

    uses org.eclipse.microprofile.rest.client.spi.RestClientBuilderListener;
    uses org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
}
```

The module name follows the `org.eclipse.microprofile.<spec>` convention (reverse-DNS of the root package, as already used by the Config API's `Automatic-Module-Name` and by the OpenAPI API's existing descriptor). `jakarta.ws.rs` (`RestClientBuilder extends Configurable`, `Response`, `MultivaluedMap` in signatures) and `jakarta.annotation` (`ResponseExceptionMapper.getPriority()` reads `@Priority`) are hard dependencies and stay `requires transitive`. `org.eclipse.microprofile.config` is only used internally by `DefaultClientHeadersFactoryImpl` and is an optional (`provided`) dependency, hence plain `requires static`. The CDI and Inject modules are only referenced by the `@RestClient` qualifier, its `RestClientLiteral` and the `@RegisterRestClient` stereotype; the builder API and the `ext`/`spi` packages do not depend on them. They are therefore declared `requires static transitive`:

- `static`: optional at resolution time, so the module resolves on a module path without a CDI container. Whenever the annotations are actually used at run time it is through a CDI container, whose own module `requires` the Jakarta modules and therefore resolves them.
- `transitive`: when they are resolved, a module using `@RestClient` or `@RegisterRestClient` reads `jakarta.cdi` and `jakarta.inject` implicitly, which is needed for the meta-annotations and the `AnnotationLiteral` supertypes to be resolvable from that module.

The same trade-off is applied to the other MicroProfile APIs whose Jakarta dependency is annotation-only (see the discussion on microprofile/microprofile-health#344, microprofile/microprofile-metrics#805 and microprofile/microprofile-fault-tolerance#660). The module Javadoc is deliberately kept to a one-liner; this rationale lives here instead.

### Build changes (`api/pom.xml`)

- The descriptor lives in `src/main/module-info/` and is compiled by a dedicated `maven-compiler-plugin` execution patched onto the already compiled classes (`--patch-module`). The main compilation is left untouched on the class path, and the descriptor does not have to `requires` the OSGi/bnd annotation jars used by `package-info.java`, which are compile-time only and ship no module descriptor of their own.
- The descriptor source root is registered with `build-helper-maven-plugin` at `prepare-package` (after compilation) so that the attached `*-sources.jar` ships `module-info.java` alongside the other sources.
- `maven-javadoc-plugin` is kept in class path mode (`legacyMode`) with an explicit `sourcepath` limited to `src/main/java`: javadoc would otherwise switch to module mode as soon as it finds a `module-info.java` at the root of a source path.
- The project baseline is Java 11, so no `--release` override is needed.
- `microprofile-config-api` is bumped from 3.1 to 3.1.1, the first service release that declares `Automatic-Module-Name: org.eclipse.microprofile.config` (3.1 only had the jar-derived name `microprofile.config.api`, which `requires` could not target).
- `ModuleDescriptorTest` (TestNG, like the existing `api` tests) reads the compiled descriptor back from the class path and checks the module name, exported packages, `uses` clauses, and the exact sets of mandatory / optional (`static`) and transitive `requires`.

### Verification

- `mvn install -DskipTests` on the whole reactor passes.
- `jar --describe-module` on the built jar shows the descriptor above; OSGi headers (`Bundle-SymbolicName`, `Export-Package`, `Import-Package`) generated by bnd are unchanged.
- `java --module-path <api jar + compile deps> --describe-module org.eclipse.microprofile.rest.client` resolves the module graph successfully (with only `jakarta.ws.rs` and `jakarta.annotation` next to the api jar it resolves as well, the CDI/Inject modules being optional).
- The `*-sources.jar` contains `module-info.java`; the `*-javadoc.jar` is unchanged.
